### PR TITLE
Dev/at42 qt1010 reset

### DIFF
--- a/iolib/buttonLib/buttonLib.py
+++ b/iolib/buttonLib/buttonLib.py
@@ -1,4 +1,7 @@
+from sys import path
+path.append("/usr/local/lib/wand/iolib")
 from ioLib2 import WandIO
+import time
 
 
 
@@ -18,6 +21,11 @@ class Button():
             # Interrupt handler for on/off ic (max16150)
             self.wand.configure_interrupt(chip_label="rpi", gpio_list=[27, "on_off_ic"], callback=callback)
 
+    def reset_button(self):
+        self.wand.set_output("mcp", 1, 0)
+        time.sleep(0.01)
+        self.wand.set_output("mcp", 1, 1)
+
     # Interrupt handler for on/off button press
     # Use set_on_off_ic_interrupt() instead unless you know what you are doing
     def set_on_off_button_interrupt(self, callback):
@@ -30,7 +38,10 @@ if __name__ == "__main__":
 
     button=Button()
     button.set_button_interrupt(callback=int_callback, button="front_top")
+    button.set_button_interrupt(callback=int_callback, button="front_button")
+    # button.wand.set_output("mcp", 1, 1)
 
     while(1):
         time.sleep(0.1)
+        
         pass

--- a/iolib/ioLib2/ioLib2.py
+++ b/iolib/ioLib2/ioLib2.py
@@ -34,6 +34,11 @@ class WandIO:
 
         self.mcp_gpio_lines = {} 
         self.rpi_gpio_lines = {}
+        
+        print(self.mcp_input_lines)
+        #pin_number, consumer = zip([1], ["button_reset"])
+        self.configure_output("mcp", gpio_list=[1, "button_reset"])
+        self.set_output("mcp", 1, 1)
 
         # Configure MCP23008 input GPIO
         # for pin_number, consumer in zip(self.mcp_input_lines[0], self.mcp_input_lines[1]):
@@ -208,10 +213,10 @@ class WandIO:
         return self.read_input("mcp",0)
         
 def test_interrupt(event):
-    print("test interrupt")
+    print("test interrupt123")
 
 def test_interrupt2(event):
-    print("test2 interrupt")
+    print("test2 interrupt1234")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
the touch buttons are can now be reset from software using an button reset function and are automatically enabled from the start of the iolib2