### PR TITLE
fixed random occuring bootloader mode

### DIFF
--- a/iolib/ioLib2/ioLib2.py
+++ b/iolib/ioLib2/ioLib2.py
@@ -35,8 +35,12 @@ class WandIO:
         self.mcp_gpio_lines = {} 
         self.rpi_gpio_lines = {}
         
+        # initialize pin state
         self.configure_output("mcp", gpio_list=[1, "button_reset"])
         self.set_output("mcp", 1, 1)
+
+        self.configure_output("rpi", gpio_list=[4, "bootloader"])
+        self.set_output("mcp", 4, 0)
 
     def configure_input(self, chip_label: str, gpio_list: List[Union[int, str]]) -> Optional[int]:
         """


### PR DESCRIPTION
Fixes a bug where the cm4 would enter bootloader on reboot by defining the bootloader pin state when running ioLib2. 