### PR TITLE
modified imuLib and other conf to bno08x

### DIFF
--- a/iolib/imuLib/imuLib.py
+++ b/iolib/imuLib/imuLib.py
@@ -1,45 +1,143 @@
-#!/bin/python3
-from adafruit_lsm6ds.lsm6ds3 import LSM6DS3
-import board
-from typing import Dict
 
-class IMU:
-    def __init__(self):
-        """
-        Initializes the IMU class with the I2C and LSM6DS3 sensor.
-        """
-        i2c = board.I2C()
-        self.sox = LSM6DS3(i2c)
+from adafruit_extended_bus import ExtendedI2C as I2C
+import time
+from adafruit_bno08x import (
+    BNO_REPORT_ACCELEROMETER,
+    BNO_REPORT_GYROSCOPE,
+    BNO_REPORT_MAGNETOMETER,
+    BNO_REPORT_GAME_ROTATION_VECTOR,
+)
+from adafruit_bno08x.i2c import BNO08X_I2C
+import math
 
-    def get_acc(self) -> Dict[str, str]:
-        """
-        Gets the acceleration values from the LSM6DS3 sensor.
 
-        Returns:
-            Dict[str, str]: A dictionary containing acceleration values for x, y, and z axes.
-        """
-        acc_state = {
-            "x": f"{self.sox.acceleration[0]:.2f}",
-            "y": f"{self.sox.acceleration[1]:.2f}",
-            "z": f"{self.sox.acceleration[2]:.2f}"
-        }
-        return acc_state
+class IMUlib:
+    '''
+    IMUlib class provides methods to interact with the BNO08X IMU sensor.
     
-    def get_gyro(self) -> Dict[str, str]:
-        """
-        Gets the gyroscope values from the LSM6DS3 sensor.
+    Methods:
+    - get_accel(): Returns the raw accelerometer readings.
+    - get_accel_norm(): Returns the normalized accelerometer readings.
+    - get_game_quaternion(): Returns the quaternion values for the game rotation vector.
+    - get_relative_rotation_vector(radians=False): Returns the relative roll, pitch, and yaw values based on the game rotation vector quaternion. 
+      If radians is True, the values are returned in radians; otherwise, they are returned in degrees.
+    '''
+    def __init__(self):
+        '''
+        Initializes the IMUlib object with the BNO08X IMU sensor.
+        '''
+        self.bno = BNO08X_I2C(I2C(8))
+        self.bno.enable_feature(BNO_REPORT_ACCELEROMETER)
+        self.bno.enable_feature(BNO_REPORT_GYROSCOPE)
+        self.bno.enable_feature(BNO_REPORT_GAME_ROTATION_VECTOR)
+    
+    def get_accel(self):
+        '''
+        Returns:
+        dict: Dictionary containing the raw accelerometer readings for x, y, and z axes.
+        '''
+        accel_x, accel_y, accel_z = self.bno.acceleration
+        accel = {
+            'x': accel_x,
+            'y': accel_y,
+            'z': accel_z
+        }
+        return accel
+    
+    def get_accel_norm(self):
+        '''
+        Returns:
+        dict: Dictionary containing the normalized accelerometer readings for x, y, and z axes.
+        '''
+        accel_x, accel_y, accel_z = self.bno.acceleration
+        magnitude = (accel_x**2 + accel_y**2 + accel_z**2)**0.5
+        normalized_x = accel_x / magnitude
+        normalized_y = accel_y / magnitude
+        normalized_z = accel_z / magnitude
+        normalized_accel = {
+            'x': normalized_x,
+            'y': normalized_y,
+            'z': normalized_z
+        }
+        return normalized_accel
+
+    def _quaternion_to_euler_angle(self, quat_i, quat_j, quat_k, quat_real):
+        '''
+        Converts quaternion to euler angles.
+
+        Args:
+        quat_i (float): Quaternion i component.
+        quat_j (float): Quaternion j component.
+        quat_k (float): Quaternion k component.
+        quat_real (float): Quaternion real component.
 
         Returns:
-            Dict[str, str]: A dictionary containing gyroscope values for x, y, and z axes.
-        """
-        gyro_state = {
-            "x": f"{self.sox.gyro[0]:.2f}",
-            "y": f"{self.sox.gyro[1]:.2f}",
-            "z": f"{self.sox.gyro[2]:.2f}",
+        tuple: Tuple containing roll, pitch, and yaw angles in radians.
+        '''
+        sinr_cosp = 2.0 * (quat_real * quat_i + quat_j * quat_k)
+        cosr_cosp = 1.0 - 2.0 * (quat_i * quat_i + quat_j * quat_j)
+        roll = math.atan2(sinr_cosp, cosr_cosp)
+
+        sinp = 2.0 * (quat_real * quat_j - quat_k * quat_i)
+        pitch = math.asin(sinp)
+
+        siny_cosp = 2.0 * (quat_real * quat_k + quat_i * quat_j)
+        cosy_cosp = 1.0 - 2.0 * (quat_j * quat_j + quat_k * quat_k)
+        yaw = math.atan2(siny_cosp, cosy_cosp)
+
+        return roll, pitch, yaw
+    
+    def get_game_quaternion(self):
+        '''
+        Returns:
+        dict: Dictionary containing the quaternion values for the game rotation vector (i, j, k, and real parts).
+        '''
+        quat_i, quat_j, quat_k, quat_real = self.bno.game_quaternion
+        game_quaternion = {
+            'i': quat_i,
+            'j': quat_j,
+            'k': quat_k,
+            'real': quat_real
         }
-        return gyro_state
+        return game_quaternion
+    
+
+    def get_relative_rotation_vector(self, radians=False):
+        '''
+        Returns the relative roll, pitch, and yaw values based on the game rotation vector quaternion.
+
+        Args:
+        radians (bool, optional): If True, returns the values in radians. If False (default), returns the values in degrees.
+
+        Returns:
+        dict: Dictionary containing the relative roll, pitch, and yaw values.
+        '''
+        game_quaternion = self.get_game_quaternion()
+        roll, pitch, yaw = self._quaternion_to_euler_angle(game_quaternion['i'], game_quaternion['j'], game_quaternion['k'], game_quaternion['real'])
+        if radians:
+            relative_rot_vector = {
+                'roll': roll,
+                'pitch': pitch,
+                'yaw': yaw
+            }
+        else:
+            relative_rot_vector = {
+                'roll': math.degrees(roll),
+                'pitch': math.degrees(pitch),
+                'yaw': math.degrees(yaw)
+            }
+        return relative_rot_vector
+
+
+def main():
+    '''
+    Main function to demonstrate the usage of IMUlib.
+    '''
+    imu = IMUlib()
+    while(1):
+        x = imu.get_relative_rotation_vector()
+        print(x)
+        time.sleep(0.01)
 
 if __name__ == "__main__":
-    imu = IMU()
-    acc_value = imu.get_acc()
-    print(acc_value["x"])
+    main()

--- a/pkg/DEBIAN/preinst
+++ b/pkg/DEBIAN/preinst
@@ -85,3 +85,10 @@ if ! grep -q "^dtoverlay=gpio-key-mtch1010,gpio=3,active_low=1,label="buttom_but
     printf "dtoverlay=gpio-key-mtch1010,gpio=3,active_low=1,label="buttom_button",keycode=0x101\n" >> /boot/config.txt 
 fi
 
+# Add software I2C on bus 8 for bno085
+sed /boot/config.txt -i -e "s/^#dtoverlay=i2c-gpio,bus=8,i2c_gpio_sda=9,i2c_gpio_scl=11/dtoverlay=i2c-gpio,bus=8,i2c_gpio_sda=9,i2c_gpio_scl=11/"
+if ! grep -q "^dtoverlay=i2c-gpio,bus=8,i2c_gpio_sda=9,i2c_gpio_scl=11" /boot/config.txt ; then 
+    printf "dtoverlay=i2c-gpio,bus=8,i2c_gpio_sda=9,i2c_gpio_scl=11\n" >> /boot/config.txt 
+fi
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ eeprom
 PySensors
 adafruit-circuitpython-lsm6ds
 zmq
+adafruit-circuitpython-bno08x
+adafruit-extended-bus


### PR DESCRIPTION
bno085 as imu in imuLib. Tested with breadboard version and software I2C on bus8 as there is a hardware bug that causes issues with clock stretching on raspberry pi.

Implemented the following functions
- get_accel_norm() -> gets normalized accelerations (x,y,z)
- get_accel() -> gets accelerations (x,y,z)
- get_game_quaternion() -> gets a quaternion with relative pose
- get_relative_rotation_vector -> gets a relative rotation vector (roll, pitch, yaw)

All functions have been tested and found to be working 